### PR TITLE
AUI-1169 Add tab key as hide event for the datepicker in active input.

### DIFF
--- a/src/aui-datepicker/js/aui-datepicker-popover.js
+++ b/src/aui-datepicker/js/aui-datepicker-popover.js
@@ -169,6 +169,7 @@ A.mix(DatePickerPopover.prototype, {
      */
     _setPopover: function(val) {
         var instance = this;
+        var activeInput = instance.get('activeInput');
 
         return A.merge({
             bodyContent: '',
@@ -179,6 +180,11 @@ A.mix(DatePickerPopover.prototype, {
                     node: _DOCUMENT,
                     eventName: 'key',
                     keyCode: 'esc'
+                },
+                {
+                    node: activeInput,
+                    eventName: 'key',
+                    keyCode: 'tab'
                 }
             ],
             position: 'bottom',

--- a/src/aui-datepicker/js/aui-datepicker.js
+++ b/src/aui-datepicker/js/aui-datepicker.js
@@ -207,11 +207,11 @@ A.mix(DatePickerBase.prototype, {
      * @param node
      */
     useInputNode: function(node) {
-        var instance = this,
-            popover = instance.getPopover();
-
-        popover.set('trigger', node);
+        var instance = this;
         instance.set('activeInput', node);
+
+        var popover = instance.getPopover();
+        popover.set('trigger', node);
 
         if (!popover.get('visible')) {
             instance.alignTo(node);


### PR DESCRIPTION
Hey @mairatma 

Merry Christmas :)

This is a fix for [AUI-1169](https://issues.liferay.com/browse/AUI-1169).

I move *instance.set('activeInput', node);* before *var popover = instance.getPopover();* so that we can get *activeInput* from *instance* in method of *_setPopover*.

But I still have a problem when dealing with [AUI-1814](https://issues.liferay.com/browse/AUI-1814).

Changing *triggerShowEvent: 'click'* to triggerShowEvent: 'focus' only has effect when tabbing to the input at second time.

When focusing on the input at the very first time, the datepicker only pops up for event 'mousedown', but not for event 'focus' event if we delegated both in datepicker-delegate.js.

I need to investigate more.

So let us solve AUI-1169 at first.

Thanks
John

