### PR TITLE
[Technical-Supoort] AUI-1880 Overlapping events don't show up correctly

### DIFF
--- a/src/aui-scheduler/HISTORY.md
+++ b/src/aui-scheduler/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1880](https://issues.liferay.com/browse/AUI-1880) Overlapping events don't show up correctly
 * [AUI-1871](https://issues.liferay.com/browse/AUI-1871) In month view, popover does not update values if an event was previously displayed
 
 ## [3.0.1](https://github.com/liferay/alloy-ui/releases/tag/3.0.1)

--- a/src/aui-scheduler/js/aui-scheduler-view-day.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-day.js
@@ -255,7 +255,7 @@ var SchedulerDayView = A.Component.create({
          */
         filterFn: {
             value: function(evt) {
-                return (evt.getHoursDuration() <= 24 && !evt.get('allDay'));
+                return (evt.get('visible') && evt.getHoursDuration() <= 24 && !evt.get('allDay'));
             }
         },
 
@@ -831,6 +831,8 @@ var SchedulerDayView = A.Component.create({
             var scheduler = instance.get('scheduler');
             var filterFn = instance.get('filterFn');
 
+            instance.get('scheduler').flushEvents();
+
             instance.columnShims.each(function(colShimNode, i) {
                 var columnEvents = scheduler.getEventsByDay(instance.getDateByColumn(i), true);
                 var plottedEvents = [];
@@ -935,43 +937,58 @@ var SchedulerDayView = A.Component.create({
          */
         syncEventsIntersectionUI: function(columnEvents) {
             var instance = this;
+            var insertedNodes = [];
             var eventWidth = instance.get('eventWidth');
-
-            instance.get('scheduler').flushEvents();
 
             A.Array.each(columnEvents, function(colEvt) {
                 var intercessors = instance.findEventIntersections(
                     colEvt, columnEvents);
 
+                var i = 0;
                 var total = intercessors.length;
                 var distributionRate = (eventWidth / total);
 
-                A.Array.each(intercessors, function(evt, j) {
-                    var evtNode = evt.get('node').item(0);
-                    var left = distributionRate * j;
-                    var width = distributionRate * 1.7;
+                A.Array.each(intercessors, function(evt) {
+                    var clientId = evt.get('clientId');
+                    var nodeIndex = A.Array.indexOf(insertedNodes, clientId);
 
-                    if (j === (total - 1)) {
-                        width = eventWidth - left;
+                    if (nodeIndex === -1) {
+                        nodeIndex = 0;
+
+                        if (evt._filtered) {
+                            nodeIndex = 1;
+                        }
+
+                        var evtNode = evt.get('node').item(nodeIndex);
+                        var left = distributionRate * i;
+                        var width = distributionRate * 1.7;
+
+                        if (i === (total - 1)) {
+                            width = eventWidth - left;
+                        }
+
+                        evtNode.setStyle('width', width + '%');
+                        evtNode.setStyle('left', left + '%');
+
+                        if (total > 1) {
+                            evtNode.addClass(CSS_SCHEDULER_EVENT_INTERSECTING);
+                        }
+                        else {
+                            evtNode.removeClass(CSS_SCHEDULER_EVENT_INTERSECTING);
+                        }
+
+                        var evtParentNode = evtNode.get('parentNode');
+
+                        if (evtParentNode) {
+                            evtParentNode.insert(evtNode, i);
+                        }
+
+                        evt._filtered = true;
+
+                        insertedNodes.push(clientId);
+
+                        i = i + 1;
                     }
-
-                    evtNode.setStyle('width', width + '%');
-                    evtNode.setStyle('left', left + '%');
-
-                    if (total > 1) {
-                        evtNode.addClass(CSS_SCHEDULER_EVENT_INTERSECTING);
-                    }
-                    else {
-                        evtNode.removeClass(CSS_SCHEDULER_EVENT_INTERSECTING);
-                    }
-
-                    var evtParentNode = evtNode.get('parentNode');
-
-                    if (evtParentNode) {
-                        evtParentNode.insert(evtNode, j);
-                    }
-
-                    evt._filtered = true;
                 });
             });
         },
@@ -1072,7 +1089,7 @@ var SchedulerDayView = A.Component.create({
             var group = [];
 
             A.Array.each(events, function(evtCmp) {
-                if (!evt._filtered && evtCmp.get('visible') && evt.intersects(evtCmp)) {
+                if (evtCmp.get('visible') && evt.intersects(evtCmp)) {
                     group.push(evtCmp);
                 }
             });

--- a/src/aui-scheduler/tests/unit/js/tests.js
+++ b/src/aui-scheduler/tests/unit/js/tests.js
@@ -497,7 +497,82 @@ YUI.add('aui-scheduler-tests', function(Y) {
                 Y.one('.scheduler-event-recorder-date').get('text'),
                 'The recorder date should NOT display the second day'
             );
-        }
+        },
+
+        'should display overlapping events correctly in week view': function() {
+            var column1,
+                column1Events,
+                column2,
+                column2Events,
+                intersectingEvents,
+                schedulerEvents;
+
+            this._createScheduler({
+                activeView: this._weekView,
+                date: new Date(2015, 02, 22),
+                firstDayOfWeek: 0,
+                items: [
+                    {
+                        content: 'Event 1',
+                        startDate: new Date(2015, 2, 25, 11, 0),
+                        endDate: new Date(2015, 2, 25, 16, 30)
+                    },
+                    {
+                        content: 'Event 2',
+                        startDate: new Date(2015, 2, 25, 15, 30),
+                        endDate: new Date(2015, 2, 25, 17, 0),
+                    },
+                    {
+                        content: 'Event 3',
+                        startDate: new Date(2015, 2, 25, 16, 0),
+                        endDate: new Date(2015, 2, 26, 11, 0),
+                    },
+                    {
+                        content: 'Event 4',
+                        startDate: new Date(2015, 2, 25, 18, 0),
+                        endDate: new Date(2015, 2, 26, 12, 30),
+                    }
+                ]
+            });
+
+            schedulerEvents = Y.all('.scheduler-event');
+
+            Y.Assert.areEqual(
+                6, schedulerEvents.size(),
+                '6 SchedulerEvent nodes should be in week view.'
+            );
+
+            intersectingEvents = Y.all('.scheduler-event.scheduler-event-intersecting');
+
+            Y.Assert.areEqual(
+                6, intersectingEvents.size(),
+                '6 intersecting SchedulerEvent nodes should be in week view.'
+            );
+
+            column1 = intersectingEvents.item(0).ancestor('.scheduler-view-day-table-colday');
+
+            column1Events = column1.all('.scheduler-event.scheduler-event-intersecting');
+
+            Y.Assert.areEqual(
+                4, column1Events.size(),
+                '4 intersecting SchedulerEvent nodes should be in column1Events column.'
+            );
+
+            column2 = intersectingEvents.item(4).ancestor('.scheduler-view-day-table-colday');
+
+            column2Events = column2.all('.scheduler-event.scheduler-event-intersecting');
+
+            Y.Assert.areEqual(
+                2, column2Events.size(),
+                '2 intersecting SchedulerEvent nodes should be in column2Events column.'
+            );
+
+            Y.Assert.areNotEqual(
+                column2Events.item(0).getStyle('left'), column2Events.item(1).getStyle('left'),
+                '2 SchedulerEvents which are intersecting with each other can not have the same left style value.'
+            );
+        },
+
     }));
 
     Y.Test.Runner.add(suite);


### PR DESCRIPTION
Hi Maira,

I'm sending you my solution for AUI-1880 where the basic issue was that plotted and overlapping events showed up incorrectly on "week" and "day" views.

Regarding of basic issue I noticed that we always get just first node of a plotted event. Thus, of course, the view of second node of plotted events aren't recalculated. During I tried to fix it I found some basic mistakes that's way I refactored this logic.

1. https://github.com/zsagia/alloy-ui/commit/3d8298a2c03a29c60a54843b44d093d42d2d269f#diff-f18ac5b7157479e7275559480fd13f04R258

We shouldn't iterate over the invisible events.

2. https://github.com/zsagia/alloy-ui/commit/3d8298a2c03a29c60a54843b44d093d42d2d269f#diff-f18ac5b7157479e7275559480fd13f04R947

Refactored logic. I used an array(specially important if we have more then 2 intersected events) for every worked events. Futhermore, based on evt._filtered value we modify nodeIndex (this can be 0 or 1). This will fix the plotted and overlapping mistake.

3. https://github.com/zsagia/alloy-ui/commit/3d8298a2c03a29c60a54843b44d093d42d2d269f#diff-f18ac5b7157479e7275559480fd13f04R1092

This is an unnecessary condition because we have handle it in another level.

Maira, if would be misunderstand-able please write me.

Thanks in advance,
 Zsaga