### PR TITLE
AUI-1997 Constrain the overlay into the scheduler (or any given element)

### DIFF
--- a/src/aui-scheduler/HISTORY.md
+++ b/src/aui-scheduler/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1997](https://issues.liferay.com/browse/AUI-1997) Overlay displaying extra events appears cropped or demands scrolling
 * [AUI-1929](https://issues.liferay.com/browse/AUI-1929) Alloy Scheduler does not add long events to each day the event occurs on in Agenda view.
 * [AUI-1920](https://issues.liferay.com/browse/AUI-1920) Calendar - Hiding calendar does not update neither events nor "Show n more" link
 * [AUI-1893](https://issues.liferay.com/browse/AUI-1893) Wrong display of recurrent overnight events in week view in the last day of first week under DST

--- a/src/aui-scheduler/js/aui-scheduler-view-table.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-table.js
@@ -158,6 +158,27 @@ var SchedulerTableView = A.Component.create({
         },
 
         /**
+         * The element or locator to constrain the events overlay.
+         *
+         * When a cell has more events than can be shown, it offers an option
+         * to open an overlay to see all of them by clicking in a "See x more"
+         * link. This overlay should be constrained by another element, lest
+         * it could be cropped or would resize the entire document.
+         *
+         * The default value is `true`, in which case the overlay is constrained
+         * to the viewport.
+         *
+         * @attribute eventsOverlayConstrain
+         * @default null
+         * @type {Boolean | Node | String}
+         * @writeOnce
+         */
+        eventsOverlayConstrain: {
+            value: true,
+            writeOnce: true
+        },
+
+        /**
          * Indicates whether the height of the `SchedulerTableView` is fixed.
          *
          * @attribute fixedHeight
@@ -1180,6 +1201,7 @@ var SchedulerTableView = A.Component.create({
                         label: strings.close
                     }
                 ),
+                constrain: instance.get('eventsOverlayConstrain'),
                 render: instance.get('boundingBox'),
                 visible: false,
                 width: 250,

--- a/src/aui-scheduler/tests/unit/js/tests.js
+++ b/src/aui-scheduler/tests/unit/js/tests.js
@@ -623,6 +623,56 @@ YUI.add('aui-scheduler-tests', function(Y) {
             );
         },
 
+        'should display the events overlay entirely': function() {
+            var events = [];
+
+            var displayDate = new Date(2014, 2, 8);
+            var eventDate = new Date(2014, 3, 5);
+
+            for (var i = 0; i < 10; i++) {
+                events.push(
+                    {
+                        color: 'c2a374',
+                        content: 'dummy ' + i,
+                        endDate: eventDate,
+                        startDate: eventDate,
+                        allDay: true
+                    }
+                );
+            }
+
+            this._createScheduler({
+              items: events,
+              date: displayDate,
+              activeView: this._monthView
+            });
+
+            Y.one('.scheduler-view-table-more').simulate('click');
+
+            var schedulerBB = this._scheduler.get('boundingBox');
+            var schedulerRect = schedulerBB._node.getBoundingClientRect();
+
+            var overlay = this._monthView.eventsOverlay;
+            var overlayBB = overlay.get('boundingBox');
+            var overlayRect = overlayBB._node.getBoundingClientRect();
+
+            Y.Assert.isTrue(
+                schedulerRect.top >= 0,
+                'The top of the events overlay should be inside the viewport.'
+            );
+            Y.Assert.isTrue(
+                overlayRect.bottom <= Y.one("body").get("winHeight"),
+                'The bottom of the events overlay should be inside the viewport.'
+            );
+            Y.Assert.isTrue(
+                schedulerRect.left >= 0,
+                'The left of the events overlay should be inside the viewport.'
+            );
+            Y.Assert.isTrue(
+                overlayRect.right <= Y.one("body").get("winWidth"),
+                'The right of the events overlay should be inside the viewport.'
+            );
+        }
     }));
 
     Y.Test.Runner.add(suite);


### PR DESCRIPTION
Hello Maíra.

Using a `valueFn` proved more complex than expected but Eduardo gave me a great tip: constraining to the viewport by default. Here is the changed version.

Please let me know of any problems.

cc @thiago-rocha.